### PR TITLE
Update sharp-ico.json

### DIFF
--- a/bucket/sharp-ico.json
+++ b/bucket/sharp-ico.json
@@ -1,11 +1,11 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.1",
     "description": "轻量级ICO图标生成和检查工具",
     "homepage": "https://github.com/star-plan/sharp-ico",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/star-plan/sharp-ico/releases/download/v1.0.0/sharpico-win-x64.zip",
+            "url": "https://github.com/star-plan/sharp-ico/releases/download/v1.1.1/SharpIco-windows-1.1.1.zip",
             "hash": "请在发布后替换为实际的SHA256哈希值"
         }
     },


### PR DESCRIPTION
The second URL doesn't follow the naming convention.

"https://github.com/star-plan/sharp-ico/releases/download/v$version/sharpico-win-x64.zip"